### PR TITLE
Explicit python2 README Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ sudo apt install -y libsdl1.2debian libfdt1 libpixman-1-0
 # Python 2.7 + pip + virtualenv
 sudo apt update
 sudo apt install python2
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 
 curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
 sudo python2 get-pip.py
 sudo -H python2.7 -m pip install -U pip setuptools wheel virtualenv

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo apt install python2
 curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
 sudo python2 get-pip.py
 sudo -H python2.7 -m pip install -U pip setuptools wheel virtualenv
-sudo apt install python-dev
+sudo apt install python2-dev
 
 # Node.js + npm (will take a few minutes if npm isn't already installed)
 sudo apt install libnode-dev npm 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Install the Python library dependencies locally:
 
 ```bash
 # Install requirements
-[ -e .env ] || virtualenv .env
+[ -e .env ] || virtualenv --python=python2.7 .env
 . .env/bin/activate
 pip install -r requirements.txt
 pip install -r pebble-tool/requirements.txt

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo apt install -y libsdl1.2debian libfdt1 libpixman-1-0
 sudo apt update
 sudo apt install python2
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 
-curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 sudo python2 get-pip.py
 sudo -H python2.7 -m pip install -U pip setuptools wheel virtualenv
 sudo apt install python2-dev


### PR DESCRIPTION
Explicitly use python2 during installation.
This is due to python3 as [default on Ubuntu](https://wiki.ubuntu.com/Python/3).